### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Dante-lor/spring-boot-operator/security/code-scanning/4](https://github.com/Dante-lor/spring-boot-operator/security/code-scanning/4)

Closes #30

In general, the fix is to explicitly specify `permissions` for the workflow or for the individual job so that the `GITHUB_TOKEN` only has the minimal scopes required. For a test-only workflow that checks out code and runs Go tests without modifying repository state, `contents: read` is typically sufficient and aligns with CodeQL’s suggested minimal starting point.

The best single change, without altering existing functionality, is to add a `permissions` block at the root of the workflow (right under `name: Tests`). This will apply to all jobs that don’t override permissions, including the `test` job. The block should look like:

```yaml
permissions:
  contents: read
```

No additional imports or external libraries are needed because this is just a YAML configuration change within `.github/workflows/test.yml`. The rest of the file remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
