### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-references-issue.yml
+++ b/.github/workflows/pr-references-issue.yml
@@ -1,5 +1,8 @@
 name: Ensure PR references issue
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, edited, synchronize]


### PR DESCRIPTION
Potential fix for [https://github.com/Dante-lor/spring-boot-operator/security/code-scanning/2](https://github.com/Dante-lor/spring-boot-operator/security/code-scanning/2)

Closes #30

In general, to fix this class of problem you add an explicit `permissions` section either at the workflow root (applies to all jobs) or under the specific job, and restrict it to the minimal required scopes. This documents the intent and prevents the workflow from accidentally gaining broader permissions if repository defaults change.

For this specific workflow, the job only needs to read the PR body from the event payload. It does not write to the repository, issues, or PRs, so the minimal safe choice is to set `permissions: contents: read` at the workflow level. This matches GitHub’s recommended “read-only token” start point and is sufficient for using `github.event.*` context data. To implement this:

- Edit `.github/workflows/pr-references-issue.yml`.
- Insert a `permissions:` block near the top level of the workflow (after `name:` or before `jobs:`), e.g.:

```yaml
permissions:
  contents: read
```

No imports or additional methods are required because this is just a YAML configuration change. Existing functionality (running a simple shell `grep` on the PR body) is unaffected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
