### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run on Ubuntu


### PR DESCRIPTION
Potential fix for [https://github.com/Dante-lor/spring-boot-operator/security/code-scanning/1](https://github.com/Dante-lor/spring-boot-operator/security/code-scanning/1)

Closes #30 

To fix the problem, explicitly restrict the GITHUB_TOKEN permissions in the workflow to the minimum needed. This is usually done either at the workflow root (applies to all jobs) or at the job level. Since this workflow only has one job and only reads repository contents, we can set `contents: read`, which aligns with the CodeQL suggestion.

The best minimal, non-breaking change is to add a `permissions:` block at the workflow root, just below the `on:` trigger block and above `jobs:`. This will apply to `lint` and any future jobs unless they override permissions. No changes to the steps are required, and no external imports or methods are needed.

Concretely, in `.github/workflows/lint.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `pull_request:` line and the `jobs:` key. This documents and enforces least privilege for the GITHUB_TOKEN used by this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
