### PR TITLE
Added links and generally improved the docs site

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,6 @@
 			"enableNonRootDocker": "true",
 			"moby": "true"
 		},
-		// for mkdocs
-		"ghcr.io/devcontainers/features/python": {},
-
 		"ghcr.io/devcontainers/features/go:1": {},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
 		"ghcr.io/devcontainers-extra/features/kind": {}

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -23,5 +23,10 @@ curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
 sudo mv kubebuilder /usr/local/bin/
 
-# mkdocs
-pip install mkdocs-material
+# zensical (Docs)
+echo 'alias zensical="docker run --rm -it -p 8000:8000  \
+    -v ${LOCAL_WORKSPACE_FOLDER}/mkdocs.yml:/docs/mkdocs.yml \
+    -v ${LOCAL_WORKSPACE_FOLDER}/docs:/docs/docs \
+    zensical/zensical"' >> ~/.bashrc
+
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,28 +1,28 @@
-name: docs-publish 
+name: Documentation
 on:
   push:
     branches:
       - main
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/configure-pages@v5
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v4
+      - run: pip install zensical
+      - run: zensical build --clean 
+      - uses: actions/upload-pages-artifact@v4
         with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: ~/.cache 
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material 
-      - run: mkdocs gh-deploy --force
+          path: site
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ More information can be found via the [Kubebuilder Documentation](https://book.k
 
 ## Updating Documentation
 
-Our docs are built with [Material For Markdown](https://squidfunk.github.io/mkdocs-material/). To host the docs locally,
+Our docs are built with [Zensical](https://zensical.org/about/). To host the docs locally,
 run this from inside the devcontainer:
 
 ```bash
-mkdocs serve
+zensical
 ```
 
 From there you will be able to edit the documentation live.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,23 @@
 site_name: Spring Boot Operator
 site_url: https://dante-lor.github.io/spring-boot-operator
+repo_url: https://github.com/dante-lor/spring-boot-operator
+repo_name: dante-lor/spring-boot-operator
 theme:
   name: material
   features:
     - content.code.copy
+  palette: 
+    # Palette toggle for light mode
+    - scheme: default
+      toggle:
+        icon: lucide/sun
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      toggle:
+        icon: lucide/moon
+        name: Switch to light mode
 markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true


### PR DESCRIPTION
## 🔗 Issue

Fixes #34  
---

## ✏️ What Changed?

This pull request updates the CI / CD workflow for docs to match that suggested by zensical. I have updated the instructions in the README.md and the devcontainer scripts so that `zensical` runs it locally. I have tested the docs myself.

By using docker to run the docs, I can avoid the need for python to be installed on the devcontainer, making it more lightweight and focussed.

I have also added some improvements, adding links to the repo and adding light / dark themes.

This pull request will ensure that our docs are future proof.

---

## 🧪 Testing

How did you verify this works?

- [x] Tested locally
- [ ] Added/updated tests (if needed)

